### PR TITLE
fix: protect /dashboard routes with Clerk middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,12 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    await auth.protect();
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Add createRouteMatcher to enforce authentication on all /dashboard(.*) routes. Unauthenticated users will be redirected by Clerk instead of reaching the page and triggering an Unauthorized error.

Fixes #4