### PR TITLE
feat: make workout cards clickable links to workout detail page

### DIFF
--- a/src/app/dashboard/workout-card.tsx
+++ b/src/app/dashboard/workout-card.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { format } from "date-fns";
 import {
   Card,
@@ -26,6 +27,7 @@ export type WorkoutWithDetails = {
 
 export function WorkoutCard({ workout }: { workout: WorkoutWithDetails }) {
   return (
+    <Link href={`/dashboard/workout/${workout.id}`} className="block transition-opacity hover:opacity-80">
     <Card>
       <CardHeader>
         <CardTitle>{workout.name ?? "Untitled Workout"}</CardTitle>
@@ -61,5 +63,6 @@ export function WorkoutCard({ workout }: { workout: WorkoutWithDetails }) {
         ))}
       </CardContent>
     </Card>
+    </Link>
   );
 }


### PR DESCRIPTION
Wrap each WorkoutCard in a Next.js Link component navigating to `/dashboard/workout/[workoutId]` with hover opacity for visual feedback.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)